### PR TITLE
README: fix uvx invocation to use relative path (tested with uvx 0.10.12 and 0.11.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ peakrdl html STM32F429.svd -o html_dir
 Or, using uvx:
 
 ```
-uvx --from peakrdl-cli -w python-packages-are-weird -w peakrdl_html peakrdl html STM32F429.svd -o html_dir
+uvx --from peakrdl-cli -w ./python-packages-are-weird -w peakrdl_html peakrdl html STM32F429.svd -o html_dir
 ```
 
 Note that things are under a directory called `python-packages-are-weird` because apparently they can't be in the current directory, and some directories like `lib` appear to be special.


### PR DESCRIPTION
Fails:

```bash
 ❯ uvx --from peakrdl-cli -w python-packages-are-weird -w peakrdl_html peakrdl html STM32F429.svd -o html_dir
  × No solution found when resolving tool dependencies:
  ╰─▶ Because python-packages-are-weird was not found in the package registry and you require python-packages-are-weird, we can conclude that your requirements are unsatisfiable.
```

Succeeds with relative path:
```bash
 ❯ uvx --from peakrdl-cli -w ./python-packages-are-weird -w peakrdl_html peakrdl html STM32F429.svd -o html_dir
      Built peakrdl-svd @ file:///home/test/peakrdl_svd/python-packages-are-weird
Installed 15 packages in 115ms
STM32F429.svd: warning: Register BWTR3 at address 0x0x104 overlaps with BWTR1 STM32F429.svd: warning: Register BWTR4 at address 0x0x10c overlaps with BWTR2 STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR2_Input at address 0x0x1c overlaps with CCMR2_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register CCMR1_Input at address 0x0x18 overlaps with CCMR1_Output STM32F429.svd: warning: Register FS_GRXSTSR_Host at address 0x0x1c overlaps with FS_GRXSTSR_Device STM32F429.svd: warning: Register FS_GNPTXFSIZ_Host at address 0x0x28 overlaps with FS_GNPTXFSIZ_Device STM32F429.svd: warning: Register OTG_HS_TX0FSIZ_Peripheral at address 0x0x28 overlaps with OTG_HS_GNPTXFSIZ_Host STM32F429.svd: warning: Register OTG_HS_GRXSTSR_Peripheral at address 0x0x1c overlaps with OTG_HS_GRXSTSR_Host STM32F429.svd: warning: Register OTG_HS_GRXSTSP_Peripheral at address 0x0x20 overlaps with OTG_HS_GRXSTSP_Host
```

Version:
```bash
 ❯ uvx --version
uvx 0.10.12 (x86_64-unknown-linux-gnu)
```